### PR TITLE
Save the log file to internal storage for Android and make the log file store only the current session logs

### DIFF
--- a/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
+++ b/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
@@ -29,8 +29,7 @@ class LogExportPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "getLogFileExportedPath") {
-      val filename = File(Environment.getExternalStoragePublicDirectory(
-              Environment.DIRECTORY_DOWNLOADS).toString() + "/logcat_export.txt")
+      val filename = File(Environment.getDataDirectory().toString() + "/logcat_export.txt")
       filename.createNewFile()
       val pid = android.os.Process.myPid();
       val cmd = "logcat -d --pid=${pid} -f ${filename.absolutePath}"

--- a/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
+++ b/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
@@ -29,7 +29,7 @@ class LogExportPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "getLogFileExportedPath") {
-      val filename = File(Environment.getDataDirectory().toString() + "/logcat_export.txt")
+      val filename = File(Environment.getFilesDir().toString() + "/logcat_export.txt")
       filename.createNewFile()
       val pid = android.os.Process.myPid();
       val cmd = "logcat -d --pid=${pid} -f ${filename.absolutePath}"

--- a/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
+++ b/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
@@ -1,6 +1,7 @@
 package com.quango.logexport.log_export
 
 import android.os.Environment
+import android.content.Context
 import android.util.Log
 import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -21,21 +22,27 @@ class LogExportPlugin: FlutterPlugin, MethodCallHandler {
   /// when the Flutter Engine is detached from the Activity
   private lateinit var channel : MethodChannel
   private lateinit var packageName : String
+  private lateinit var context: Context
+  private lateinit var logFile: File
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "log_export")
-    packageName = flutterPluginBinding.applicationContext.packageName
+    context = flutterPluginBinding.applicationContext
+    logFile = File(context.getFilesDir().toString() + "/logcat_export.txt")
+    if(logFile.exists()) {
+      logFile.delete()
+    }
+    packageName = context.packageName
     channel.setMethodCallHandler(this)
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "getLogFileExportedPath") {
-      val filename = File(Environment.getFilesDir().toString() + "/logcat_export.txt")
-      filename.createNewFile()
+      logFile.createNewFile()
       val pid = android.os.Process.myPid();
-      val cmd = "logcat -d --pid=${pid} -f ${filename.absolutePath}"
+      val cmd = "logcat -d --pid=${pid} -f ${logFile.absolutePath}"
       val process = Runtime.getRuntime().exec(cmd)
       process.waitFor()
-      result.success(filename.absolutePath)
+      result.success(logFile.absolutePath)
     } else {
       result.notImplemented()
     }

--- a/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
+++ b/android/src/main/kotlin/com/quango/logexport/log_export/LogExportPlugin.kt
@@ -29,7 +29,7 @@ class LogExportPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "getLogFileExportedPath") {
-      val filename = File(Environment.getExternalStoragePublicDirectory(
+      val filename = File(Environment.getDataDirectory(
               Environment.DIRECTORY_DOWNLOADS).toString() + "/logcat_export.txt")
       filename.createNewFile()
       val pid = android.os.Process.myPid();


### PR DESCRIPTION
For newer versions of Android we had to ask users permission to external storage in order to use this package and I think this shouldn't be necessary so I saved the log file in the application internal storgae. Also I think that the current session logs should be enough in order to debug or check different application information or erros, otherwise the log file could become very large.